### PR TITLE
Terminate file contents with 0

### DIFF
--- a/include/res_embed.gas.in
+++ b/include/res_embed.gas.in
@@ -5,7 +5,7 @@
 
 @OS_DEPENDENT_PREFIX@hex_content_@FILE_KEY_HASH@:
 .incbin "@FILE_PATH@"
-
+.byte 0
 .global @OS_DEPENDENT_PREFIX@hex_size_@FILE_KEY_HASH@
 
 @OS_DEPENDENT_PREFIX@hex_size_@FILE_KEY_HASH@:


### PR DESCRIPTION
Terminating file content with 0 to prevent problems regarding null termination with ascii files.
