### PR TITLE
Set RES_EMBED_USE_SHARED for add_subdirectory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(
 
 option(BUILD_SHARED_LIBS
        "Build and use shared library for ${PROJECT_NAME} (default: ON)" ON)
+set(RES_EMBED_USE_SHARED ${BUILD_SHARED_LIBS} PARENT_SCOPE)
 
 option(BUILD_EXAMPLE "Build the examples (default: ON)" ON)
 


### PR DESCRIPTION
This variable is used for determining linkage type in ResEmbed function and it is defined in res_embedConfig.cmake which is utilized when res embed is installed as a package in the system. In order to use resembed by add_subdirectory we need to set this variable and for it to take effect we need to set scope to parent scope.