### PR TITLE
fix: pass GCC force-include headers as single arguments

### DIFF
--- a/cmake/ResEmbed.cmake
+++ b/cmake/ResEmbed.cmake
@@ -40,7 +40,7 @@ function(res_embed)
 		configure_file("${RES_EMBED_CURRENT_INCLUDE_DIR}/res_embed_force_include.hpp.in" "${_FORCE_INCLUDE_PATH}" @ONLY)
 		target_compile_options(${RES_EMBED_TARGET} PRIVATE
 			"$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/FI${_FORCE_INCLUDE_PATH}>"
-			"$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-include;${_FORCE_INCLUDE_PATH}>")
+			"$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-include${_FORCE_INCLUDE_PATH}>")
 	endif()
 
 	set(EMBED_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${RES_EMBED_NAME}${RES_EMBED_ASM_EXT}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ res_embed(TARGET resource_test NAME "binary" PATH ${CMAKE_CURRENT_SOURCE_DIR}/re
 add_library(static_resource_lib STATIC static_lib.cpp)
 target_include_directories(static_resource_lib PRIVATE ../include)
 res_embed(TARGET static_resource_lib NAME "static_resource" PATH ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource1.txt KEYWORD)
+res_embed(TARGET static_resource_lib NAME "static_resource_extra" PATH ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource2.txt KEYWORD)
 
 add_executable(static_resource_test static_main.cpp)
 target_link_libraries(static_resource_test PRIVATE static_resource_lib)

--- a/test/static_lib.cpp
+++ b/test/static_lib.cpp
@@ -6,3 +6,8 @@ extern "C" const char* static_resource_get(size_t* size)
 {
     return res::embed::get("static_resource", size);
 }
+
+extern "C" const char* static_resource_extra_get(size_t* size)
+{
+    return res::embed::get("static_resource_extra", size);
+}

--- a/test/static_main.cpp
+++ b/test/static_main.cpp
@@ -3,25 +3,39 @@
 #include <iostream>
 
 extern "C" const char* static_resource_get(size_t* size);
+extern "C" const char* static_resource_extra_get(size_t* size);
+
+static int check_resource(const char* name, const char* data, size_t size, const char* expected)
+{
+    if (!data) {
+        std::cerr << name << " is missing" << std::endl;
+        return 1;
+    }
+
+    size_t expected_size = std::strlen(expected);
+    if (size != expected_size) {
+        std::cerr << name << " size mismatch" << std::endl;
+        return 1;
+    }
+
+    if (std::memcmp(data, expected, size) != 0) {
+        std::cerr << name << " content mismatch" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
 
 int main()
 {
     size_t size = 0;
     const char* data = static_resource_get(&size);
-    const char expected[] = "Test resource 1\n";
-
-    if (!data) {
-        std::cerr << "Static library resource is missing" << std::endl;
+    if (check_resource("Static library resource", data, size, "Test resource 1\n") != 0) {
         return 1;
     }
 
-    if (size != sizeof(expected) - 1) {
-        std::cerr << "Static library resource size mismatch" << std::endl;
-        return 1;
-    }
-
-    if (std::memcmp(data, expected, size) != 0) {
-        std::cerr << "Static library resource content mismatch" << std::endl;
+    data = static_resource_extra_get(&size);
+    if (check_resource("Static library extra resource", data, size, "Test resource 2 with different content!\n") != 0) {
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- Pass each GCC/Clang force-include header as a single `-include<path>` argument instead of splitting `-include` and `<path>` with a semicolon inside the generator expression.
- Fixes builds with many embedded resources where CMake/Ninja emits one `-include` followed by many header paths, causing GCC to treat later headers as extra input files.

## Reproducer
`eye_recordings` with 100+ embedded frames exposed this after the static-library resource embedding fix: the compile command became:

```text
c++ ... -include frame0_force_include.hpp frame1_force_include.hpp ... -o object.o -c source.cpp
```

GCC then fails with:

```text
c++: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
```

Using `-include${_FORCE_INCLUDE_PATH}` keeps every forced include as an independent compiler option and avoids treating the following headers as sources.

## Test plan
- Verified locally in `gladius_test_server` with `ThirdParty/res_embed/test`:
  - `resource_test`
  - `static_resource_test`
  - `embed_file_script_mode`
- Verified `eye_recordings_test` builds and runs with 100+ embedded frames.